### PR TITLE
chore: add lefthook pre-commit checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,23 @@ A simple WebAssembly (WASI) example using Go and Wazero runtime.
 ## Requirements
 
 - Go 1.25.0 or later
+- aqua
+
+## Development
+
+Install development tools with aqua:
+
+```bash
+aqua i
+```
+
+Install lefthook:
+
+```bash
+lefthook install
+```
+
+lefthook runs `golangci-lint run --enable gosec`, a WASI build check, and `go test -v ./...` before commit.
 
 ## Build
 
@@ -21,4 +38,3 @@ Execute the WASI module with Wazero:
 ```bash
 go run main.go
 ```
-

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+- type: standard
+  ref: v4.493.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+- name: golangci/golangci-lint@v2.11.4
+- name: evilmartians/lefthook@v2.1.6

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,12 @@
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      glob: "*.go"
+      run: golangci-lint run --enable gosec
+    build-wasm:
+      glob: "*.go"
+      run: GOOS=wasip1 GOARCH=wasm go build -o /tmp/gowasi-main.wasm wasi/main.go
+    test:
+      glob: "*.go"
+      run: go test -v ./...


### PR DESCRIPTION
## Summary
- add lefthook managed by aqua
- run golangci-lint, a WASI build check, and go test before commit
- document aqua and lefthook setup in README

## Verification
- aqua exec -- lefthook validate
- aqua exec -- golangci-lint run --enable gosec
- GOOS=wasip1 GOARCH=wasm go build -o /tmp/gowasi-main.wasm wasi/main.go
- go test -v ./...
- aqua exec -- lefthook run pre-commit --all-files