### PR TITLE
[codex] Add actions security checks

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -1,0 +1,36 @@
+name: GitHub Actions Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  actions-security:
+    name: Check workflows
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install aqua tools
+        uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+        with:
+          aqua_version: v2.56.6
+
+      - name: Check action pinning
+        run: pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Audit workflows
+        run: zizmor --format github .
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,12 +4,17 @@ on:
   push:
   pull_request:
 
+
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: ./go.mod
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
@@ -20,8 +25,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: ./go.mod
       - name: build wasm

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -8,8 +8,10 @@
 #   supported_envs:
 #   - all
 registries:
-- type: standard
-  ref: v4.493.0 # renovate: depName=aquaproj/aqua-registry
+  - type: standard
+    ref: v4.493.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-- name: golangci/golangci-lint@v2.11.4
-- name: evilmartians/lefthook@v2.1.6
+  - name: golangci/golangci-lint@v2.11.4
+  - name: evilmartians/lefthook@v2.1.6
+  - name: suzuki-shunsuke/pinact@v4.0.0
+  - name: zizmorcore/zizmor@v1.25.2


### PR DESCRIPTION
## Summary
- Pin GitHub Actions references to commit SHAs with pinact annotations
- Add aqua-managed pinact and zizmor tools
- Add a GitHub Actions Security workflow that installs tools via aqua and runs pinact/zizmor
- Set read-only workflow permissions and disable checkout credential persistence where applicable

## Validation
- actionlint .github/workflows/*.{yml,yaml}
- git diff --check -- .github/workflows aqua.yaml

Note: this is stacked on `feat/lefthook` to avoid mixing that existing work into a main-targeted PR.